### PR TITLE
Update for Terraform 0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    mcaf = {
+      source = "terraform.schubergphilis.com/schubergphilis/mcaf"
+    }
+  }
 }


### PR DESCRIPTION
When using Terraform 0.13 and an in-house provider, we need to specify the source.