### PR TITLE
Update for schubergphilis/mcaf v0.4.2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,10 +40,11 @@ jobs:
         continue-on-error: true # added this to prevent a PR from a remote fork failing the workflow
 
   tfsec:
-    name: tfsec
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@master
-      - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+      - name: Terraform pr commenter
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        with:
+          github_token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-mcaf-account
 
-MCAF terraform module to create an AWS account using Control Tower's Account Factory
+MCAF terraform module to create an AWS account using Control Tower's Account Factory.
 
 <!--- BEGIN_TF_DOCS --->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ MCAF terraform module to create an AWS account using Control Tower's Account Fac
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| mcaf | >= 0.3 |
+| mcaf | >= 0.4.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| mcaf | >= 0.3 |
+| mcaf | >= 0.4.2 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "mcaf_aws_account" "default" {
   name                     = var.account
   email                    = var.email
-  organizational_unit      = var.organizational_unit
+  organizational_unit_path = var.organizational_unit
   provisioned_product_name = var.provisioned_product_name
 
   sso {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mcaf = {
       source  = "schubergphilis/mcaf"
-      version = ">= 0.3"
+      version = ">= 0.4.2"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
v0.4.2 of [schubergphilis/mcaf](https://github.com/schubergphilis/terraform-provider-mcaf) deprecates the `organizational_unit` field and adds `organizational_unit_path` as it now supports provisioning an account into a nested OU.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
